### PR TITLE
Allow managed skill symlinks resolving outside skills root

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -131,6 +131,30 @@ describe("loadWorkspaceSkillEntries", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "loads managed skills whose symlinks resolve outside the managed root",
+    async () => {
+      const workspaceDir = await createTempWorkspaceDir();
+      const managedDir = path.join(workspaceDir, ".managed");
+      await fs.mkdir(managedDir, { recursive: true });
+      const outsideDir = await createTempWorkspaceDir();
+      const externalSkillDir = path.join(outsideDir, "ext-skill");
+      await writeSkill({
+        dir: externalSkillDir,
+        name: "ext-skill",
+        description: "External symlinked skill",
+      });
+      await fs.symlink(externalSkillDir, path.join(managedDir, "ext-skill"), "dir");
+
+      const entries = loadWorkspaceSkillEntries(workspaceDir, {
+        managedSkillsDir: managedDir,
+        bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      });
+
+      expect(entries.map((entry) => entry.skill.name)).toContain("ext-skill");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "skips workspace skill directories that resolve outside the workspace root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -204,12 +204,16 @@ function resolveContainedSkillPath(params: {
   rootDir: string;
   rootRealPath: string;
   candidatePath: string;
+  allowExternalSymlinks?: boolean;
 }): string | null {
   const candidateRealPath = tryRealpath(params.candidatePath);
   if (!candidateRealPath) {
     return null;
   }
   if (isPathInside(params.rootRealPath, candidateRealPath)) {
+    return candidateRealPath;
+  }
+  if (params.allowExternalSymlinks) {
     return candidateRealPath;
   }
   warnEscapedSkillPath({
@@ -226,6 +230,7 @@ function filterLoadedSkillsInsideRoot(params: {
   source: string;
   rootDir: string;
   rootRealPath: string;
+  allowExternalSymlinks?: boolean;
 }): Skill[] {
   return params.skills.filter((skill) => {
     const baseDirRealPath = resolveContainedSkillPath({
@@ -233,6 +238,7 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.baseDir,
+      allowExternalSymlinks: params.allowExternalSymlinks,
     });
     if (!baseDirRealPath) {
       return false;
@@ -242,6 +248,7 @@ function filterLoadedSkillsInsideRoot(params: {
       rootDir: params.rootDir,
       rootRealPath: params.rootRealPath,
       candidatePath: skill.filePath,
+      allowExternalSymlinks: params.allowExternalSymlinks,
     });
     return Boolean(skillFileRealPath);
   });
@@ -300,7 +307,11 @@ function loadSkillEntries(
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config);
 
-  const loadSkills = (params: { dir: string; source: string }): Skill[] => {
+  const loadSkills = (params: {
+    dir: string;
+    source: string;
+    allowExternalSymlinks?: boolean;
+  }): Skill[] => {
     const rootDir = path.resolve(params.dir);
     const rootRealPath = tryRealpath(rootDir) ?? rootDir;
     const resolved = resolveNestedSkillsRoot(params.dir, {
@@ -312,6 +323,7 @@ function loadSkillEntries(
       rootDir,
       rootRealPath,
       candidatePath: baseDir,
+      allowExternalSymlinks: params.allowExternalSymlinks,
     });
     if (!baseDirRealPath) {
       return [];
@@ -325,6 +337,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: rootSkillMd,
+        allowExternalSymlinks: params.allowExternalSymlinks,
       });
       if (!rootSkillRealPath) {
         return [];
@@ -350,6 +363,7 @@ function loadSkillEntries(
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
+        allowExternalSymlinks: params.allowExternalSymlinks,
       });
     }
 
@@ -386,6 +400,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillDir,
+        allowExternalSymlinks: params.allowExternalSymlinks,
       });
       if (!skillDirRealPath) {
         continue;
@@ -399,6 +414,7 @@ function loadSkillEntries(
         rootDir,
         rootRealPath: baseDirRealPath,
         candidatePath: skillMd,
+        allowExternalSymlinks: params.allowExternalSymlinks,
       });
       if (!skillMdRealPath) {
         continue;
@@ -425,6 +441,7 @@ function loadSkillEntries(
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,
+          allowExternalSymlinks: params.allowExternalSymlinks,
         }),
       );
 
@@ -472,6 +489,7 @@ function loadSkillEntries(
   const managedSkills = loadSkills({
     dir: managedSkillsDir,
     source: "openclaw-managed",
+    allowExternalSymlinks: true,
   });
   const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
   const personalAgentsSkills = loadSkills({


### PR DESCRIPTION
## Summary
- Managed skills (`~/.openclaw/skills`) are user-controlled, so symlinks pointing to external directories (e.g. `~/.claude/skills/`) should be trusted rather than rejected
- Adds `allowExternalSymlinks` flag to `resolveContainedSkillPath` and threads it through `loadSkills`/`filterLoadedSkillsInsideRoot`, enabled only for the `openclaw-managed` source
- Workspace and plugin skills still enforce strict realpath containment

## Test plan
- [x] Existing 7 tests pass (workspace symlink rejection still enforced)
- [x] New test: managed skill with symlink resolving outside root is loaded successfully