### PR TITLE
feat: add claude memory search backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ changelog/fragments/
 
 # Local scratch workspace
 .tmp/
+*.tgz

--- a/extensions/memory-core/src/memory/claude-manager.ts
+++ b/extensions/memory-core/src/memory/claude-manager.ts
@@ -1,0 +1,264 @@
+import { spawn } from "node:child_process";
+import { readFile as fsReadFile, stat } from "node:fs/promises";
+import { copyFile } from "node:fs/promises";
+import path from "node:path";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  type ResolvedClaudeConfig,
+  type MemoryEmbeddingProbeResult,
+  type MemoryProviderStatus,
+  type MemorySearchManager,
+  type MemorySearchResult,
+  type MemorySource,
+  type MemorySyncProgressUpdate,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+
+const log = createSubsystemLogger("memory:claude");
+
+const SEARCH_PROMPT_TEMPLATE = (query: string) =>
+  `Search through the session files and memory files for: ${query}
+
+I want file paths and extracted key information from the files.
+
+Output each match in this format, separated by ---:
+
+[2026-04-07 19:34] sessions/65d81ff6.jsonl
+
+The user asked about setting up a proxy server on port 18800.
+They wanted to bridge mobile connections through a Cloudflare tunnel.
+
+---
+
+[2026-04-09 16:42] memory/2026-04-09.md
+
+## Proxy architecture
+- Port 18800 for REST + WS
+- Cloudflare tunnel auto-starts on launch
+
+---`;
+
+export class ClaudeMemoryManager implements MemorySearchManager {
+  private readonly config: ResolvedClaudeConfig;
+
+  constructor(config: ResolvedClaudeConfig) {
+    this.config = config;
+  }
+
+  async search(
+    query: string,
+    _opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
+  ): Promise<MemorySearchResult[]> {
+    const prompt = SEARCH_PROMPT_TEMPLATE(query);
+
+    const args = [
+      "-p",
+      prompt,
+      "--output-format",
+      "stream-json",
+      "--add-dir",
+      this.config.sessionsDir,
+      "--add-dir",
+      this.config.workspaceDir,
+    ];
+
+    try {
+      const { text, sessionId } = await this.runClaude(args);
+      if (sessionId) {
+        await this.copySessionJsonl(sessionId);
+      }
+      return this.parseResults(text);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`claude search failed: ${message}`);
+      throw err;
+    }
+  }
+
+  async readFile(params: {
+    relPath: string;
+    from?: number;
+    lines?: number;
+  }): Promise<{ text: string; path: string }> {
+    const relPath = params.relPath?.trim();
+    if (!relPath) {
+      throw new Error("path required");
+    }
+
+    // Try workspace first, then sessions dir
+    let absPath = path.join(this.config.workspaceDir, relPath);
+    try {
+      await stat(absPath);
+    } catch {
+      absPath = path.join(this.config.sessionsDir, relPath);
+      try {
+        await stat(absPath);
+      } catch {
+        return { text: "", path: relPath };
+      }
+    }
+
+    try {
+      const content = await fsReadFile(absPath, "utf-8");
+      const allLines = content.split("\n");
+      const start = (params.from ?? 1) - 1;
+      const count = params.lines ?? allLines.length;
+      const text = allLines.slice(start, start + count).join("\n");
+      return { text, path: relPath };
+    } catch {
+      return { text: "", path: relPath };
+    }
+  }
+
+  status(): MemoryProviderStatus {
+    return {
+      backend: "claude",
+      provider: "claude-cli",
+      custom: { type: "llm-search" },
+    };
+  }
+
+  async sync(_params?: {
+    reason?: string;
+    force?: boolean;
+    sessionFiles?: string[];
+    progress?: (update: MemorySyncProgressUpdate) => void;
+  }): Promise<void> {
+    // No index to maintain — no-op
+  }
+
+  async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
+    return { ok: false, error: "Claude backend does not use embeddings" };
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    return false;
+  }
+
+  async close(): Promise<void> {
+    // Nothing to clean up
+  }
+
+  // ── Private helpers ──────────────────────────────────────────
+
+  private async runClaude(args: string[]): Promise<{ text: string; sessionId: string | null }> {
+    return new Promise((resolve, reject) => {
+      const child = spawn("claude", args, {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env },
+      });
+
+      const chunks: Buffer[] = [];
+      child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+      let stderr = "";
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      child.on("error", (err) => {
+        reject(new Error(`Failed to spawn claude: ${err.message}`));
+      });
+
+      child.on("close", (code) => {
+        const raw = Buffer.concat(chunks).toString("utf-8");
+
+        if (code !== 0 && !raw.trim()) {
+          reject(new Error(`claude exited with code ${code}: ${stderr.trim() || "no output"}`));
+          return;
+        }
+
+        let sessionId: string | null = null;
+        let text = "";
+
+        for (const line of raw.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const event = JSON.parse(line);
+            // Extract session_id from the init event
+            if (event.type === "system" && event.session_id) {
+              sessionId = event.session_id;
+            }
+            // Collect text from assistant messages
+            if (event.type === "assistant" && event.message?.content) {
+              for (const block of event.message.content) {
+                if (block.type === "text" && block.text) {
+                  text += block.text;
+                }
+              }
+            }
+            // Also grab result text as fallback
+            if (event.type === "result" && event.result && !text) {
+              text = event.result;
+            }
+          } catch {
+            // Skip non-JSON lines
+          }
+        }
+
+        resolve({ text, sessionId });
+      });
+    });
+  }
+
+  private async copySessionJsonl(sessionId: string): Promise<void> {
+    try {
+      // Claude stores sessions at ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+      // The encoded CWD replaces / with -
+      const home = process.env.HOME ?? "";
+      const cwd = process.cwd();
+      const encodedCwd = cwd.replace(/\//g, "-");
+      const sourcePath = path.join(home, ".claude", "projects", encodedCwd, `${sessionId}.jsonl`);
+      const destPath = path.join(this.config.sessionsDir, `${sessionId}.jsonl`);
+
+      await copyFile(sourcePath, destPath);
+      log.info(`copied search session ${sessionId}.jsonl to agent sessions`);
+    } catch (err) {
+      // Non-fatal — the search still worked, we just couldn't persist the session
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`failed to copy search session jsonl: ${message}`);
+    }
+  }
+
+  private parseResults(text: string): MemorySearchResult[] {
+    if (!text.trim() || text.includes("NO_RESULTS")) {
+      return [];
+    }
+
+    const blocks = text.split(/\n---\n|\n---$/).filter((b) => b.trim());
+    const results: MemorySearchResult[] = [];
+
+    for (let i = 0; i < blocks.length; i++) {
+      const block = blocks[i].trim();
+      if (!block) continue;
+
+      const lines = block.split("\n");
+      // First line should be like: [2026-04-07 19:34] sessions/65d81ff6.jsonl
+      const headerMatch = lines[0]?.match(/^\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})\]\s+(.+)$/);
+
+      let filePath: string;
+      let snippet: string;
+
+      if (headerMatch) {
+        filePath = headerMatch[2].trim();
+        snippet = lines.slice(1).join("\n").trim();
+      } else {
+        // No header match — treat entire block as snippet, use index as path
+        filePath = `match-${i + 1}`;
+        snippet = block;
+      }
+
+      const source: MemorySource = filePath.includes("sessions") ? "sessions" : "memory";
+
+      results.push({
+        path: filePath,
+        startLine: 1,
+        endLine: 1,
+        score: 1.0 - i * 0.01, // rank-based synthetic score
+        snippet,
+        source,
+      });
+    }
+
+    return results;
+  }
+}

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -96,6 +96,48 @@ export async function getMemorySearchManager(params: {
     }
   }
 
+  if (resolved.backend === "claude" && resolved.claude) {
+    try {
+      const { ClaudeMemoryManager } = await import("./claude-manager.js");
+      const primary = new ClaudeMemoryManager(resolved.claude);
+      const wrapper = new FallbackMemoryManager({
+        primary,
+        fallbackFactory: async () => {
+          // claude → qmd → builtin fallback chain
+          try {
+            // Force QMD resolution by overriding backend in config
+            const qmdCfg = {
+              ...params.cfg,
+              memory: { ...params.cfg.memory, backend: "qmd" as const },
+            };
+            const qmdResolved = resolveMemoryBackendConfig({
+              cfg: qmdCfg,
+              agentId: params.agentId,
+            });
+            if (qmdResolved.backend === "qmd" && qmdResolved.qmd) {
+              const { QmdMemoryManager } = await import("./qmd-manager.js");
+              const qmd = await QmdMemoryManager.create({
+                cfg: qmdCfg,
+                agentId: params.agentId,
+                resolved: qmdResolved,
+                mode: "full",
+              });
+              if (qmd) return qmd;
+            }
+          } catch {
+            // QMD not available, fall through to builtin
+          }
+          const { MemoryIndexManager } = await loadManagerRuntime();
+          return await MemoryIndexManager.get(params);
+        },
+      });
+      return { manager: wrapper };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`claude memory unavailable; falling back: ${message}`);
+    }
+  }
+
   try {
     const { MemoryIndexManager } = await loadManagerRuntime();
     const manager = await MemoryIndexManager.get(params);

--- a/packages/memory-host-sdk/src/engine-storage.ts
+++ b/packages/memory-host-sdk/src/engine-storage.ts
@@ -18,6 +18,7 @@ export {
 export { readMemoryFile } from "./host/read-file.js";
 export { resolveMemoryBackendConfig } from "./host/backend-config.js";
 export type {
+  ResolvedClaudeConfig,
   ResolvedMemoryBackendConfig,
   ResolvedQmdConfig,
   ResolvedQmdMcporterConfig,

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../../../../src/agents/agent-scope.js";
 import { parseDurationMs } from "../../../../src/cli/parse-duration.js";
 import type { OpenClawConfig } from "../../../../src/config/config.js";
+import { resolveStateDir } from "../../../../src/config/paths.js";
 import type { SessionSendPolicyConfig } from "../../../../src/config/types.base.js";
 import type {
   MemoryBackend,
@@ -14,10 +15,17 @@ import type {
 import { resolveUserPath } from "../../../../src/utils.js";
 import { splitShellArgs } from "../../../../src/utils/shell-argv.js";
 
+export type ResolvedClaudeConfig = {
+  agentId: string;
+  sessionsDir: string;
+  workspaceDir: string;
+};
+
 export type ResolvedMemoryBackendConfig = {
   backend: MemoryBackend;
   citations: MemoryCitationsMode;
   qmd?: ResolvedQmdConfig;
+  claude?: ResolvedClaudeConfig;
 };
 
 export type ResolvedQmdCollection = {
@@ -300,6 +308,20 @@ export function resolveMemoryBackendConfig(params: {
 }): ResolvedMemoryBackendConfig {
   const backend = params.cfg.memory?.backend ?? DEFAULT_BACKEND;
   const citations = params.cfg.memory?.citations ?? DEFAULT_CITATIONS;
+  if (backend === "claude") {
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+    const stateDir = resolveStateDir();
+    return {
+      backend: "claude",
+      citations,
+      claude: {
+        agentId: params.agentId,
+        sessionsDir: path.join(stateDir, "agents", params.agentId, "sessions"),
+        workspaceDir,
+      },
+    };
+  }
+
   if (backend !== "qmd") {
     return { backend: "builtin", citations };
   }

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -22,7 +22,7 @@ export type MemorySyncProgressUpdate = {
 };
 
 export type MemoryProviderStatus = {
-  backend: "builtin" | "qmd";
+  backend: "builtin" | "qmd" | "claude";
   provider: string;
   model?: string;
   requestedProvider?: string;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -51,7 +51,7 @@ export async function noteMemorySearchHealth(
     note("No active memory plugin is registered for the current config.", "Memory search");
     return;
   }
-  if (backendConfig.backend === "qmd") {
+  if (backendConfig.backend === "qmd" || backendConfig.backend === "claude") {
     return;
   }
 

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -400,7 +400,7 @@ const TARGET_KEYS = [
 
 const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "memory.citations": ['"auto"', '"on"', '"off"'],
-  "memory.backend": ['"builtin"', '"qmd"'],
+  "memory.backend": ['"builtin"', '"qmd"', '"claude"'],
   "memory.qmd.searchMode": ['"query"', '"search"', '"vsearch"'],
   "models.mode": ['"merge"', '"replace"'],
   "models.providers.*.auth": ['"api-key"', '"token"', '"oauth"', '"aws-sdk"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -876,7 +876,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Caches computed chunk embeddings in SQLite so reindexing and incremental updates run faster (default: true). Keep this enabled unless investigating cache correctness or minimizing disk usage.",
   memory: "Memory backend configuration (global).",
   "memory.backend":
-    'Selects the global memory engine: "builtin" uses OpenClaw memory internals, while "qmd" uses the QMD sidecar pipeline. Keep "builtin" unless you intentionally operate QMD.',
+    'Selects the global memory engine: "builtin" uses OpenClaw memory internals, "qmd" uses the QMD sidecar pipeline, and "claude" uses the Claude CLI for LLM-powered search. Keep "builtin" unless you intentionally operate QMD or have Claude CLI installed.',
   "memory.citations":
     'Controls citation visibility in replies: "auto" shows citations when useful, "on" always shows them, and "off" hides them. Keep "auto" for a balanced signal-to-noise default.',
   "memory.qmd.command":

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -1,6 +1,6 @@
 import type { SessionSendPolicyConfig } from "./types.base.js";
 
-export type MemoryBackend = "builtin" | "qmd";
+export type MemoryBackend = "builtin" | "qmd" | "claude";
 export type MemoryCitationsMode = "auto" | "on" | "off";
 export type MemoryQmdSearchMode = "query" | "search" | "vsearch";
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -113,7 +113,7 @@ const MemoryQmdSchema = z
 
 const MemorySchema = z
   .object({
-    backend: z.union([z.literal("builtin"), z.literal("qmd")]).optional(),
+    backend: z.union([z.literal("builtin"), z.literal("qmd"), z.literal("claude")]).optional(),
     citations: z.union([z.literal("auto"), z.literal("on"), z.literal("off")]).optional(),
     qmd: MemoryQmdSchema.optional(),
   })

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -39,8 +39,9 @@ export type RegisteredMemorySearchManager = {
 };
 
 export type MemoryRuntimeBackendConfig = {
-  backend: "builtin" | "qmd";
+  backend: "builtin" | "qmd" | "claude";
   qmd?: object;
+  claude?: object;
 };
 
 export type MemoryPluginRuntime = {

--- a/test/helpers/memory-tool-manager-mock.ts
+++ b/test/helpers/memory-tool-manager-mock.ts
@@ -3,7 +3,7 @@ import { vi } from "vitest";
 export type SearchImpl = () => Promise<unknown[]>;
 export type MemoryReadParams = { relPath: string; from?: number; lines?: number };
 export type MemoryReadResult = { text: string; path: string };
-type MemoryBackend = "builtin" | "qmd";
+type MemoryBackend = "builtin" | "qmd" | "claude";
 
 let backend: MemoryBackend = "builtin";
 let searchImpl: SearchImpl = async () => [];


### PR DESCRIPTION
## Summary

- Add `"claude"` as a third memory search backend alongside `builtin` and `qmd`
- When configured (`memory.backend: "claude"`), `memory_search` shells out to `claude -p` which reads session transcripts and memory files using natural language comprehension
- Implements `ClaudeMemoryManager` in `extensions/memory-core/src/memory/claude-manager.ts`
- Falls back to QMD then builtin if Claude CLI is unavailable (`FallbackMemoryManager` chain)
- Search session JSONL is copied from `~/.claude/projects/` to the agent's sessions dir for future recall

## Test plan

- [x] `pnpm typecheck` passes (52 pre-existing errors, 0 new)
- [x] `pnpm test -- --run extensions/memory-core/src/memory/search-manager.test.ts` passes
- [x] `pnpm test -- --run src/config/schema.help.quality.test.ts` passes
- [x] `pnpm test -- --run packages/memory-host-sdk/src/host/backend-config.test.ts` passes
- [x] `pnpm test -- --run src/commands/doctor-memory-search.test.ts` passes